### PR TITLE
Correct the scoop bucket name for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sudo snap install imgcat
 First, [install scoop](https://github.com/lukesampson/scoop#installation).
 
 ```
-scoop bucket add org https://github.com/danielgatis/scoop-imgcat.git
+scoop bucket add scoop-imgcat https://github.com/danielgatis/scoop-imgcat.git
 scoop install scoop-imgcat/imgcat
 ```
 


### PR DESCRIPTION
Change the bucket name from org to scoop-imgcat for installation on Windows using scoop