### PR TITLE
Update Go build & install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ First, [install Go](https://golang.org/doc/install).
 Next, fetch and build the binary.
 
 ```bash
+go install github.com/danielgatis/imgcat@latest
+```
+
+or, if you use pre-1.17 Go version, use the `go get` command: 
+
+```bash
 go get -u github.com/danielgatis/imgcat
 ```
 


### PR DESCRIPTION
Since Go 1.17 `go get` should not be used to install applications (it is still used for adding dependencies to projects).  A separate command, `go install` was introduced for that purpose.