### PR TITLE
Add interpolation choice flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ const ANSI_FG_TRANSPARENT_COLOR = "\x1b[0m "
 const ANSI_FG_RGB_COLOR = "\x1b[38;2;%d;%d;%dm▄"
 const ANSI_RESET = "\x1b[0m"
 
+var InterpolationType = imaging.Lanczos
+
 func read(input string) []byte {
 	var err error
 	var buf []byte
@@ -159,7 +161,7 @@ func scale(frames []image.Image) []image.Image {
 
 	for i, f := range frames {
 		go func(i int, f image.Image) {
-			c <- &data{i, imaging.Fit(f, w, h, imaging.Lanczos)}
+			c <- &data{i, imaging.Fit(f, w, h, InterpolationType)}
 		}(i, f)
 	}
 
@@ -266,12 +268,20 @@ func print(frames [][]string) {
 }
 
 func main() {
-	flag.Parse()
+	interpolation := flag.String("interpolation", "lanczos", "Interpolation method. Options: lanczos, nearest")
+	ParseFlags()
 
 	input := ""
 	if len(flag.Args()) > 0 {
 		args := flag.Args()
 		input = args[0]
+	}
+
+	switch *interpolation {
+	case "nearest":
+		InterpolationType = imaging.NearestNeighbor
+	default:
+		InterpolationType = imaging.Lanczos
 	}
 
 	print(escape(scale(decode(read(input)))))

--- a/positional_flagset.go
+++ b/positional_flagset.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"os"
+)
+
+// Via https://stackoverflow.com/a/74146375/199475
+
+// ParseFlags parses the command line args, allowing flags to be
+// specified after positional args.
+func ParseFlags() error {
+	return ParseFlagSet(flag.CommandLine, os.Args[1:])
+}
+
+// ParseFlagSet works like flagset.Parse(), except positional arguments are not
+// required to come after flag arguments.
+func ParseFlagSet(flagset *flag.FlagSet, args []string) error {
+	var positionalArgs []string
+	for {
+		if err := flagset.Parse(args); err != nil {
+			return err
+		}
+		// Consume all the flags that were parsed as flags.
+		args = args[len(args)-flagset.NArg():]
+		if len(args) == 0 {
+			break
+		}
+		// There's at least one flag remaining and it must be a positional arg since
+		// we consumed all args that were parsed as flags. Consume just the first
+		// one, and retry parsing, since subsequent args may be flags.
+		positionalArgs = append(positionalArgs, args[0])
+		args = args[1:]
+	}
+	// Parse just the positional args so that flagset.Args()/flagset.NArgs()
+	// return the expected value.
+	// Note: This should never return an error.
+	return flagset.Parse(positionalArgs)
+}


### PR DESCRIPTION
This PR adds a nearest-neighbor interpolation option that can be specified in the command line. Note that I had to pull in additional code to allow for parsing the filename as a positional argument in any order, but that could be removed if we can assume that flags must precede the file name if flags are passed. 

Note that although the inspiration for this PR is #6 , this PR doesn't fully resolve that issue—I still get spurious color in some grayscale images, but it improves the display in most of them.