### PR TITLE
ansi reset

### DIFF
--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func print(frames [][]string) {
 			<-tick
 		}
 	}
-
+	os.Stdout.WriteString(ANSI_RESET)
 	os.Stdout.WriteString(ANSI_CURSOR_SHOW)
 }
 


### PR DESCRIPTION
Added line for ANSI RESET. Without this line, if the program is stopped with CTRL + C, the text written is not visible anymore until a "reset" command is run. 

Tested on Fedora Linux 40.