### PR TITLE
Allow user to specify image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ imgcat path/to/image.png
 - `-interpolation`: Set interpolation method (default: `lanczos`)
   - `nearest`: Fastest resampling filter, no antialiasing.
   - `lanczos`: A high-quality resampling filter for photographic images yielding sharp results.
-- `-silent`: Hide Exit message (default: false). 
-- `-top-offset`: Offset from the top of the terminal to start rendering the image (default 8)
-- `-type`: Image resize type. Options: fit, resize (default "fit")
+- `-type`: Image resize type. Options: fit, resize (default: `fit`)
+- `-cols`: Number of terminal columns to use for rendering the image (default: terminal width)
+- `-rows`: Number of terminal rows to use for rendering the image (default: terminal height)
+- `-top-offset`: Offset from the top of the terminal to start rendering the image (default: 1)
+- `-silent`: Hide exit message (default: false)
 
 ### Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielgatis/imgcat
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/creack/pty v1.1.24
@@ -8,10 +8,8 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.8
 	github.com/mat/besticon v3.12.0+incompatible
 	github.com/mattn/go-isatty v0.0.20
-	golang.org/x/sys v0.39.0
+	golang.org/x/image v0.42.0
+	golang.org/x/sys v0.46.0
 )
 
-require (
-	golang.org/x/image v0.34.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
-)
+require golang.org/x/net v0.48.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/danielgatis/imgcat
 
-go 1.24.1
+go 1.24.0
 
 require (
 	github.com/creack/pty v1.1.24
@@ -8,8 +8,10 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.8
 	github.com/mat/besticon v3.12.0+incompatible
 	github.com/mattn/go-isatty v0.0.20
-	golang.org/x/image v0.39.0
-	golang.org/x/sys v0.32.0
+	golang.org/x/sys v0.39.0
 )
 
-require golang.org/x/net v0.39.0 // indirect
+require (
+	golang.org/x/image v0.34.0 // indirect
+	golang.org/x/net v0.48.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -9,11 +9,11 @@ github.com/mat/besticon v3.12.0+incompatible/go.mod h1:mA1auQYHt6CW5e7L9HJLmqVQC
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
-golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
-golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
-golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
+golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
+golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
-golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -9,11 +9,11 @@ github.com/mat/besticon v3.12.0+incompatible/go.mod h1:mA1auQYHt6CW5e7L9HJLmqVQC
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
-golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
+golang.org/x/image v0.42.0 h1:1gSs6ehNWXLbkHBIPcWztk3D/6aIA/8hauiAYtlodVY=
+golang.org/x/image v0.42.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
-golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -22,27 +22,31 @@ import (
 	"golang.org/x/image/webp"
 )
 
-var RESIZE_OFFSET_Y = 8
-const RESIZE_FACTOR_Y = 2
-const RESIZE_FACTOR_X = 1
-const DEFAULT_TERM_COLS = 80
-const DEFAULT_TERM_ROWS = 24
-const FPS = 15
+const (
+	RESIZE_FACTOR_Y   = 2
+	RESIZE_FACTOR_X   = 1
+	DEFAULT_TERM_COLS = 80
+	DEFAULT_TERM_ROWS = 24
+	FPS               = 15
+)
 
-const ANSI_CURSOR_UP = "\x1B[%dA"
-const ANSI_CURSOR_HIDE = "\x1B[?25l"
-const ANSI_CURSOR_SHOW = "\x1B[?25h"
-const ANSI_BG_TRANSPARENT_COLOR = "\x1b[0;39;49m"
-const ANSI_BG_RGB_COLOR = "\x1b[48;2;%d;%d;%dm"
-const ANSI_FG_TRANSPARENT_COLOR = "\x1b[0m "
-const ANSI_FG_RGB_COLOR = "\x1b[38;2;%d;%d;%dm▄"
-const ANSI_RESET = "\x1b[0m"
+const (
+	ANSI_CURSOR_UP            = "\x1B[%dA"
+	ANSI_CURSOR_HIDE          = "\x1B[?25l"
+	ANSI_CURSOR_SHOW          = "\x1B[?25h"
+	ANSI_BG_TRANSPARENT_COLOR = "\x1b[0;39;49m"
+	ANSI_BG_RGB_COLOR         = "\x1b[48;2;%d;%d;%dm"
+	ANSI_FG_TRANSPARENT_COLOR = "\x1b[0m "
+	ANSI_FG_RGB_COLOR         = "\x1b[38;2;%d;%d;%dm▄"
+	ANSI_RESET                = "\x1b[0m"
+)
 
-var InterpolationType = imaging.Lanczos
-var imageOperation = imaging.Fit
-
-var NUM_ADDITIONAL_LINES = 2
-var SILENT = "false"
+var (
+	interpolationType = imaging.Lanczos
+	imageOperation    = imaging.Fit
+	topOffset         = 1
+	silent            = false
+)
 
 func read(input string) []byte {
 	var err error
@@ -133,7 +137,7 @@ func decode(buf []byte) []image.Image {
 
 		imb := frame.Bounds()
 		if imb.Max.X < 2 || imb.Max.Y < 2 {
-			log.Fatal("the input image is to small")
+			log.Fatal("the input image is too small")
 		}
 
 		frames = append(frames, frame)
@@ -160,7 +164,7 @@ func scale(frames []image.Image) []image.Image {
 	}
 
 	w := cols * RESIZE_FACTOR_X
-	h := (rows - RESIZE_OFFSET_Y) * RESIZE_FACTOR_Y
+	h := (rows - topOffset) * RESIZE_FACTOR_Y
 
 	l := len(frames)
 	r := make([]image.Image, l)
@@ -168,7 +172,7 @@ func scale(frames []image.Image) []image.Image {
 
 	for i, f := range frames {
 		go func(i int, f image.Image) {
-			c <- &data{i, imageOperation(f, w, h, InterpolationType)}
+			c <- &data{i, imageOperation(f, w, h, interpolationType)}
 		}(i, f)
 	}
 
@@ -240,7 +244,9 @@ func print(frames [][]string) {
 	}
 
 	os.Stdout.WriteString(ANSI_CURSOR_HIDE)
-	os.Stdout.WriteString("\n")
+	for i := 0; i < topOffset; i++ {
+		os.Stdout.WriteString("\n")
+	}
 
 	frameCount := len(frames)
 
@@ -249,9 +255,12 @@ func print(frames [][]string) {
 	} else {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
+		defer signal.Stop(c)
 
-		tick := time.Tick(time.Second / time.Duration(FPS))
-		h := len(frames[0]) + NUM_ADDITIONAL_LINES // two extra lines for the exit msg
+		h := len(frames[0])
+		if !silent {
+			h += 2 // two extra lines for the exit msg
+		}
 		playing := true
 
 		go func() {
@@ -259,17 +268,20 @@ func print(frames [][]string) {
 			playing = false
 		}()
 
+		tick := time.NewTicker(time.Second / time.Duration(FPS))
+		defer tick.Stop()
+
 		for i := 0; playing; i++ {
 			if i != 0 {
 				os.Stdout.WriteString(fmt.Sprintf(ANSI_CURSOR_UP, h))
 			}
 
 			os.Stdout.WriteString(strings.Join(frames[i%frameCount], ""))
-			if SILENT == "false" {
+			if !silent {
 				os.Stdout.WriteString("\npress `ctrl c` to exit\n")
 			}
 
-			<-tick
+			<-tick.C
 		}
 	}
 	os.Stdout.WriteString(ANSI_RESET)
@@ -278,9 +290,9 @@ func print(frames [][]string) {
 
 func main() {
 	interpolation := flag.String("interpolation", "lanczos", "Interpolation method. Options: lanczos, nearest")
-	silent := flag.String("silent", "false", "Hide Exit message. Options: true, false")
 	resizeType := flag.String("type", "fit", "Image resize type. Options: fit, resize")
-	flag.IntVar(&RESIZE_OFFSET_Y, "top-offset",RESIZE_OFFSET_Y , "Offset from the top of the terminal to start rendering the image")
+	flag.IntVar(&topOffset, "top-offset", topOffset, "Offset from the top of the terminal to start rendering the image")
+	flag.BoolVar(&silent, "silent", false, "Hide exit message")
 
 	ParseFlags()
 
@@ -292,20 +304,14 @@ func main() {
 
 	switch *interpolation {
 	case "nearest":
-		InterpolationType = imaging.NearestNeighbor
+		interpolationType = imaging.NearestNeighbor
 	default:
-		InterpolationType = imaging.Lanczos
-	}
-
-	if *silent != "false" {
-		NUM_ADDITIONAL_LINES = 0
-		SILENT = *silent
+		interpolationType = imaging.Lanczos
 	}
 
 	if *resizeType != "fit" {
 		imageOperation = imaging.Resize
 	}
-
 
 	print(escape(scale(decode(read(input)))))
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ const (
 var (
 	interpolationType = imaging.Lanczos
 	imageOperation    = imaging.Fit
+	termCols          = 0
+	termRows          = 0
 	topOffset         = 1
 	silent            = false
 )
@@ -146,22 +148,37 @@ func decode(buf []byte) []image.Image {
 	return frames
 }
 
+func imgSize() (rows, cols int) {
+	// figure out real terminal size
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		rows, cols, _ = pty.Getsize(os.Stdout)
+	}
+
+	// account user specified size override
+	if termRows > 0 {
+		rows = termRows
+	}
+	if termCols > 0 {
+		cols = termCols
+	}
+
+	// fallback to default terminal size
+	if rows < 1 {
+		rows = DEFAULT_TERM_ROWS
+	}
+	if cols < 1 {
+		cols = DEFAULT_TERM_COLS
+	}
+	return
+}
+
 func scale(frames []image.Image) []image.Image {
 	type data struct {
 		i  int
 		im image.Image
 	}
 
-	var err error
-
-	cols := DEFAULT_TERM_COLS
-	rows := DEFAULT_TERM_ROWS
-
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		if rows, cols, err = pty.Getsize(os.Stdout); err != nil {
-			log.Panicf("failed to get the terminal size: %v", err)
-		}
-	}
+	rows, cols := imgSize()
 
 	w := cols * RESIZE_FACTOR_X
 	h := (rows - topOffset) * RESIZE_FACTOR_Y
@@ -291,6 +308,8 @@ func print(frames [][]string) {
 func main() {
 	interpolation := flag.String("interpolation", "lanczos", "Interpolation method. Options: lanczos, nearest")
 	resizeType := flag.String("type", "fit", "Image resize type. Options: fit, resize")
+	flag.IntVar(&termCols, "cols", termCols, "Number of terminal columns to use for rendering the image")
+	flag.IntVar(&termRows, "rows", termRows, "Number of terminal rows to use for rendering the image")
 	flag.IntVar(&topOffset, "top-offset", topOffset, "Offset from the top of the terminal to start rendering the image")
 	flag.BoolVar(&silent, "silent", false, "Hide exit message")
 
@@ -309,8 +328,11 @@ func main() {
 		interpolationType = imaging.Lanczos
 	}
 
-	if *resizeType != "fit" {
+	switch *resizeType {
+	case "resize":
 		imageOperation = imaging.Resize
+	default:
+		imageOperation = imaging.Fit
 	}
 
 	print(escape(scale(decode(read(input)))))


### PR DESCRIPTION
This PR mainly introduces the options to specify `rows` and `cols` using flags. It also fixes the `top-offset` changes made in #24 and updates the golang.org/x/* dependencies.

Example usage for `rows` and `cols` - use FZF with a preview made by the `imgcat`:
```shell
... | fzf --prompt="Image preview: " --preview="imgcat {1} -cols=\${FZF_PREVIEW_COLUMNS} -rows=\${FZF_PREVIEW_LINES} -top-offset=0" --preview-window="right,50%,wrap"
```